### PR TITLE
Changed error message to "Invalid membership number or password." 

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -9,10 +9,10 @@ en:
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account was not activated yet."
-      invalid: "Invalid email or password."
+      invalid: "Invalid membership number or password."
       invalid_token: "Invalid authentication token."
       locked: "Your account is locked."
-      not_found_in_database: "Invalid email or password."
+      not_found_in_database: "Invalid membership number or password."
       timeout: "Your session expired, please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your account before continuing."

--- a/features/step_definitions/signin_steps.rb
+++ b/features/step_definitions/signin_steps.rb
@@ -56,5 +56,5 @@ And /^the membership number is incorrect$/ do
 end
 
 Then /^I should have recieve an error$/ do
-  page.should have_content "Invalid email or password"
+  page.should have_content "Invalid membership number or password"
 end


### PR DESCRIPTION
... when login fails

At the moment, it's still the Devise default of "Email address"
