### PR TITLE
Freeze time earlier in tests

### DIFF
--- a/features/business_directory.feature
+++ b/features/business_directory.feature
@@ -3,6 +3,9 @@ Feature: Adding details to the organization directory
 
 	As a member, I want my details to be listed on the organization directory and stored in capsule
 
+  Background:
+    Given time is frozen
+
 	Scenario: Sucessful organization directory upload
 			
 		Given that I have signed up

--- a/features/step_definitions/business_directory_steps.rb
+++ b/features/step_definitions/business_directory_steps.rb
@@ -1,3 +1,7 @@
+Given(/^time is frozen$/) do
+  Timecop.freeze
+end
+
 Given /^that I have signed up$/ do
   steps %Q{
     Given that I want to sign up
@@ -68,7 +72,6 @@ Then /^I enter the organization name '(.*?)'$/ do |org_name|
 end
 
 When /^I click submit$/ do
-  Timecop.freeze
   fill_in("member_current_password", :with => 'p4ssw0rd')
   click_button('Save')
 end


### PR DESCRIPTION
To avoid wibbly wobbly timey wimey test failures. This should fix the flickering test failures we're seeing on the release tagger.
