### PR TITLE
Disable TLS for sending email

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,7 @@ MemberDirectory::Application.configure do
     :address => "localhost",
     :port => 25,
     :domain => "theodi.org",
-    :openssl_verify_mode => 'none'
+    :enable_starttls_auto => false,
+    #:openssl_verify_mode => 'none'
   }
 end


### PR DESCRIPTION
because of Rails 3.2.13 issue: https://github.com/rails/rails/issues/9780
