### PR TITLE
Add pattern attribute to check for a dot after the @

### DIFF
--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -65,7 +65,9 @@
 
     <%= form_field f, :cached_contact_email do %>
       <%= f.email_field :cached_contact_email, :class => 'input-large',
-                       :'data-bind' => "value: contactEmail, valueUpdate: 'afterkeydown'" %>
+                       :'data-bind' => "value: contactEmail, valueUpdate: 'afterkeydown'",
+                       :pattern => "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z.]+",
+                       :title => "Please enter a valid email address" %>
     <% end %>
 	
     <%= form_field f, :cached_twitter do %>


### PR DESCRIPTION
Because while `foo@bar` is _technically_ a valid email address, it won't be for our purposes. Also added a `title` attribute to give a more helpful error message.
