### PR TITLE
Random upload fail fix

### DIFF
--- a/app/uploaders/image_object_uploader.rb
+++ b/app/uploaders/image_object_uploader.rb
@@ -2,56 +2,26 @@
 
 class ImageObjectUploader < CarrierWave::Uploader::Base
 
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-
-  # Include the Sprockets helpers for Rails 3.1+ asset pipeline compatibility:
-  # include Sprockets::Helpers::RailsHelper
-  # include Sprockets::Helpers::IsolatedHelper
-
-  # Choose what kind of storage to use for this uploader:
-  # storage :file
+  
+  process :convert => 'png'
+  
   storage :fog
+  #storage :file
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
-  #def store_dir
-  #  "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  #end
   def store_dir
     "logos/#{model.member.membership_number}"
   end
 
-
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process :scale => [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_white_list
     %w(jpg jpeg gif png)
   end
 
   def filename
-    "original.#{file.extension}" if original_filename
+    "original.png" if original_filename
   end
 
   version :rectangular do
-    process :convert => 'png'
     process :resize_to_fit => [200,100]
     def full_filename (for_file = model.member.logo)
       "rectangular.png"
@@ -59,8 +29,7 @@ class ImageObjectUploader < CarrierWave::Uploader::Base
   end
 
   version :square do
-    process :convert => 'png'
-    process :resize_to_fill => [100,100]
+    process :resize_to_fit => [100,100]
     def full_filename (for_file = model.member.logo)
       "square.png"
     end


### PR DESCRIPTION
We suspect this was because we were trying to convert to png AND resize in each version, which may have been causing some confusion. We now convert the original file and then resize. Multiple tests seem to confirm that it is, indeed, fixed.

Fixes #131
