### PR TITLE
De-emphasise 'more information' buttons

### DIFF
--- a/app/views/organizations/_summary.erb
+++ b/app/views/organizations/_summary.erb
@@ -14,7 +14,7 @@
     
     <div class='organization-description clearfix'>
       <p property="description"><%= organization_description(organization) %></p>
-      <%= link_to "#{organization.member == current_member ? "Edit" : "More"} information &raquo;".html_safe, organization.member, :class=>'btn btn-primary pull-right' %>
+      <%= link_to "#{organization.member == current_member ? "Edit" : "More"} information &raquo;".html_safe, organization.member, :class=>'btn pull-right' %>
     </div>
   </div>
 


### PR DESCRIPTION
Buttons are now grey.

![screen shot 2013-07-05 at 10 52 01](https://f.cloud.github.com/assets/3565/753010/bff9bd20-e558-11e2-961e-34fdda8783e9.png)
