### PR TITLE
Fix extra-encoding in edit form

### DIFF
--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -88,7 +88,7 @@
     <script type="text/javascript">
         function OrganisationViewModel() {
             this.name         = ko.observable("<%= organization.name %>");
-            this.description  = ko.observable("<%= escape_javascript(strip_tags(organization.description).html_safe) %>");
+            this.description  = ko.observable("<%= escape_javascript(strip_tags(organization.description).html_safe) rescue nil %>");
             this.url          = ko.observable("<%= organization.url %>");
             this.imageSrc     = ko.observable("url(<%= organization.logo.rectangular.url %>)");
             this.contactName  = ko.observable("<%= organization.cached_contact_name %>");
@@ -97,7 +97,7 @@
             this.twitter      = ko.observable("<%= organization.cached_twitter %>");
             this.facebook     = ko.observable("<%= organization.cached_facebook %>");
             this.linkedin     = ko.observable("<%= organization.cached_linkedin %>");
-            this.tagline      = ko.observable("<%= escape_javascript(strip_tags(organization.cached_tagline).html_safe) %>");
+            this.tagline      = ko.observable("<%= escape_javascript(strip_tags(organization.cached_tagline).html_safe) rescue nil %>");
             this.mailto       = ko.computed(function() {
               return 'mailto:' + this.contactEmail();
             }, this);


### PR DESCRIPTION
resolves #260 and theodi/shared#211.

Couldn't replicate in tests, as it's all javascript and browser-side. Fix is to stop the HTML-encoding of the values, but this makes it unsafe, so I've added a strip_tags call as well to prevent injection of malicious user data.
