### PR TITLE
Strip extra space in organization name earlier on

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -111,6 +111,10 @@ class Member < ActiveRecord::Base
     product_name == "supporter"
   end
 
+  def organization_name=(value)
+    @organization_name = value.try(:strip)
+  end
+
   def stripe_customer
     Stripe::Customer.retrieve(stripe_customer_id) if stripe_customer_id
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,7 +10,7 @@ class Organization < ActiveRecord::Base
   attr_writer     :remote
   
   # Using after_save here so we get the right image urls
-  before_save :strip_twitter_prefix, :strip_spaces
+  before_save :strip_twitter_prefix
   after_save :send_to_capsule
   skip_callback :save, :after, :send_to_capsule, :if => lambda { self.remote === true }
   
@@ -41,10 +41,6 @@ class Organization < ActiveRecord::Base
     self.cached_twitter = self.cached_twitter.last(-1) if self.cached_twitter.try(:starts_with?, '@')
   end
 
-  def strip_spaces
-    self.name.try(:strip!)
-  end
-    
   def send_to_capsule
     if valid? && changed?
       organization = {

--- a/features/signup.feature
+++ b/features/signup.feature
@@ -90,6 +90,7 @@ Feature: Add new signups to queue
     And I enter my details
     And I choose to pay by invoice
     And my organisation name is "Doge Enterprises Inc. "
+    But my organisation name is expected to be "Doge Enterprises Inc."
     Then my details should be queued for further processing
     When I click sign up
     And I should have a membership number generated

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -190,6 +190,10 @@ And (/^my organisation name is "(.*?)"$/) do |org_name|
   fill_in('member_organization_name', :with => @organization_name)
 end
 
+And (/^my organisation name is expected to be "(.*?)"$/) do |org_name|
+  @organization_name = org_name
+end
+
 Then (/^my organisation name should be "(.*?)"$/) do |org_name|
   @member.organization.name.should == org_name
 end


### PR DESCRIPTION
So it doesn’t propagate through the payment processing

Fixes #256 
