### PR TITLE
Add Resque setup

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,5 @@
+Resque.redis = Redis.new(
+  :host => ENV['RESQUE_REDIS_HOST'],
+  :port => ENV['RESQUE_REDIS_PORT'],
+  :password => (ENV['RESQUE_REDIS_PASSWORD'].nil? || ENV['RESQUE_REDIS_PASSWORD']=='' ? nil : ENV['RESQUE_REDIS_PASSWORD'])
+)


### PR DESCRIPTION
It seems that since https://github.com/theodi/open-orgn-services/commit/1b36a52cb7a5cbd95328c30b395ce691436a4063, the Resque setup no longer happens in the open-orgn-services gem, which is probably correct, but we didn't follow this through here, so when we updated the Gemfile to use the latest version of the code, Resque was trying to connect to local Redis, which won't work. This could quite possibly be the cause of #382 and #379