### PR TITLE
Fetch all coupons from chargify

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -190,7 +190,7 @@ class Member < ActiveRecord::Base
     end
     product_family_ids.each do |product_family_id|
       Chargify::Coupon.all(params: {product_family_id: product_family_id}).each do |coupon|
-        register_chargify_coupon_code(coupon.code, coupon.percentage)
+        register_chargify_coupon_code(coupon.code, coupon.percentage) unless coupon.archived_at.present?
       end
     end
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -177,6 +177,7 @@ class Member < ActiveRecord::Base
   end
 
   def self.initialize_chargify_links!
+    product_family_ids = Set.new
     Chargify::Product.all.each do |product|
       # yep, this is how good the chargify API naming is
       # also no way to find the currency of a Site either
@@ -185,9 +186,12 @@ class Member < ActiveRecord::Base
       if page
         register_chargify_product_link(product.handle, page.url)
       end
+      product_family_ids.add(product.product_family.id)
     end
-    Chargify::Coupon.all.each do |coupon|
-      register_chargify_coupon_code(coupon.code, coupon.percentage)
+    product_family_ids.each do |product_family_id|
+      Chargify::Coupon.all(params: {product_family_id: product_family_id}).each do |coupon|
+        register_chargify_coupon_code(coupon.code, coupon.percentage)
+      end
     end
   end
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -120,15 +120,18 @@ describe Member do
     end
 
     it 'stores coupon discounts' do
-      full = double('coupon', archived_at: nil)
-      half = double('coupon', archived_at: nil)
-      amount = double('coupon', archived_at: nil)
-      allow(full).to receive(:percentage).and_return(100)
-      allow(full).to receive(:code).and_return("FULL")
-      allow(half).to receive(:percentage).and_return(50)
-      allow(half).to receive(:code).and_return("HALF")
-      allow(amount).to receive(:percentage).and_return(nil)
-      allow(amount).to receive(:code).and_return("AMOUNT")
+      full = double('coupon',
+        archived_at: nil,
+        percentage: 100,
+        code: "FULL")
+      half = double('coupon',
+        archived_at: nil,
+        percentage: 50,
+        code: "HALF")
+      amount = double('coupon',
+        archived_at: nil,
+        percentage: nil,
+        code: "AMOUNT")
       product1 = double('product', product_family: double(:id => 1), handle: 'a', public_signup_pages: [], price_in_cents: 1)
       product2 = double('product', product_family: double(:id => 2), handle: 'b', public_signup_pages: [], price_in_cents: 1)
       allow(Chargify::Product).to receive(:all).and_return([product1, product2])
@@ -143,14 +146,16 @@ describe Member do
     end
 
     it 'ignores archived coupons' do
-      present = double('coupon', archived_at: nil)
-      archived = double('coupon', archived_at: 3.days.ago)
-      allow(present).to receive(:percentage).and_return(100)
-      allow(present).to receive(:code).and_return("PRESENT")
-      allow(archived).to receive(:percentage).and_return(nil)
-      allow(archived).to receive(:code).and_return("ARCHIVED")
-      product1 = double('product', product_family: double(:id => 1), handle: 'a', public_signup_pages: [], price_in_cents: 1)
-      allow(Chargify::Product).to receive(:all).and_return([product1])
+      present = double('coupon',
+        archived_at: nil,
+        percentage: 100,
+        code: "PRESENT")
+      archived = double('coupon',
+        archived_at: 3.days.ago,
+        percentage: nil,
+        code: "ARCHIVED")
+      product = double('product', product_family: double(:id => 1), handle: 'a', public_signup_pages: [], price_in_cents: 1)
+      allow(Chargify::Product).to receive(:all).and_return([product])
       expect(Chargify::Coupon).to receive(:all).with(params: {product_family_id: 1}).and_return([present, archived])
       Member.initialize_chargify_links!
       expect(Member::CHARGIFY_COUPON_DISCOUNTS).to eq({

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -87,6 +87,7 @@ describe Member do
       page = double('page')
       allow(page).to receive(:url).and_return("http://i.am/an/url")
       allow(product).to receive(:price_in_cents)
+      allow(product).to receive(:product_family).and_return(double('pf', id: 1))
       allow(product).to receive(:handle).and_return("plan_name")
       allow(product).to receive(:public_signup_pages).and_return([page])
       expect(Chargify::Product).to receive(:all).and_return([product])
@@ -97,6 +98,7 @@ describe Member do
     it 'handles a missing signup page' do
       product = double('product')
       allow(product).to receive(:price_in_cents)
+      allow(product).to receive(:product_family).and_return(double('pf', id: 1))
       allow(product).to receive(:handle).and_return("plan_name")
       allow(product).to receive(:public_signup_pages).and_return([])
       expect(Chargify::Product).to receive(:all).and_return([product])
@@ -108,6 +110,7 @@ describe Member do
       product = double('product')
       page = double('page')
       allow(product).to receive(:price_in_cents).and_return(80000)
+      allow(product).to receive(:product_family).and_return(double('pf', id: 1))
       allow(product).to receive(:handle).and_return("plan_name")
       allow(product).to receive(:public_signup_pages).and_return([])
       expect(Chargify::Product).to receive(:all).and_return([product])
@@ -125,8 +128,11 @@ describe Member do
       allow(half).to receive(:code).and_return("HALF")
       allow(amount).to receive(:percentage).and_return(nil)
       allow(amount).to receive(:code).and_return("AMOUNT")
-      allow(Chargify::Product).to receive(:all).and_return([])
-      expect(Chargify::Coupon).to receive(:all).and_return([full, half, amount])
+      product1 = double('product', product_family: double(:id => 1), handle: 'a', public_signup_pages: [], price_in_cents: 1)
+      product2 = double('product', product_family: double(:id => 2), handle: 'b', public_signup_pages: [], price_in_cents: 1)
+      allow(Chargify::Product).to receive(:all).and_return([product1, product2])
+      expect(Chargify::Coupon).to receive(:all).with(params: {product_family_id: 1}).and_return([full, amount])
+      expect(Chargify::Coupon).to receive(:all).with(params: {product_family_id: 2}).and_return([half])
       Member.initialize_chargify_links!
       expect(Member::CHARGIFY_COUPON_DISCOUNTS).to eq({
         "FULL" => :free,


### PR DESCRIPTION
Coupon.all was not returning all coupons

  - now performs a more thorough lookup
  - ignores archived coupons.