### PR TITLE
Allow abandoned signups to be continued cleanly

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -27,6 +27,8 @@ class RegistrationsController < Devise::RegistrationsController
       if resource.abandoned_signup?
         new_resource = resource.class.where(email: resource.email).first
         if new_resource.valid_password?(resource.password)
+        sign_out(resource)
+        resource.delete
           redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
         end
       end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -29,7 +29,9 @@ class RegistrationsController < Devise::RegistrationsController
         password = resource.password
         sign_out(resource)
         resource.delete
+
         if new_resource.valid_password?(password)
+          sign_in(new_resource)
           redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
         else
           flash.alert = "You have already started the signup process, to continue to payment, please login.<br /> Forgotten your password? Just click the \"Forgotten password?\" link and we'll send you a link to reset it.".html_safe

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -10,6 +10,24 @@ class RegistrationsController < Devise::RegistrationsController
     respond_with resource
   end
 
+  def create
+    resource = build_resource
+
+    if resource.save
+      if resource.active_for_authentication?
+        set_flash_message :notice, :signed_up if is_navigational_format?
+        sign_up(resource_name, resource)
+        respond_with resource, :location => after_sign_up_path_for(resource)
+      else
+        set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_navigational_format?
+        expire_session_data_after_sign_in!
+        respond_with resource, :location => after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      respond_with resource
+    end
+  end
   protected
 
   def is_navigational_format?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -24,10 +24,15 @@ class RegistrationsController < Devise::RegistrationsController
         respond_with resource, :location => after_inactive_sign_up_path_for(resource)
       end
     else
+      if resource.abandoned_signup?
+        new_resource = resource.class.where(email: resource.email).first
+        redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
+      end
       clean_up_passwords resource
       respond_with resource
     end
   end
+
   protected
 
   def is_navigational_format?
@@ -55,6 +60,10 @@ class RegistrationsController < Devise::RegistrationsController
 
   def individual?
     resource.individual?
+  end
+
+  def sign_up_params
+    devise_parameter_sanitizer.sanitize(:sign_up)
   end
 
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -26,7 +26,9 @@ class RegistrationsController < Devise::RegistrationsController
     else
       if resource.abandoned_signup?
         new_resource = resource.class.where(email: resource.email).first
-        redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
+        if new_resource.valid_password?(resource.password)
+          redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
+        end
       end
       clean_up_passwords resource
       respond_with resource

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -26,9 +26,10 @@ class RegistrationsController < Devise::RegistrationsController
     else
       if resource.abandoned_signup?
         new_resource = resource.class.where(email: resource.email).first
-        if new_resource.valid_password?(resource.password)
+        password = resource.password
         sign_out(resource)
         resource.delete
+        if new_resource.valid_password?(password)
           redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
         end
       end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -31,6 +31,9 @@ class RegistrationsController < Devise::RegistrationsController
         resource.delete
         if new_resource.valid_password?(password)
           redirect_to(payment_member_path new_resource, coupon: params[:coupon].presence) and return
+        else
+          flash.alert = "You have already started the signup process, to continue to payment, please login.<br /> Forgotten your password? Just click the \"Forgotten password?\" link and we'll send you a link to reset it.".html_safe
+          redirect_to(new_member_session_path(login: new_resource.membership_number)) and return
         end
       end
       clean_up_passwords resource

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -150,7 +150,7 @@ class Member < ActiveRecord::Base
   end
 
   def abandoned_signup?
-    errors.messages[:email] && errors.messages[:email].include?("has already been taken") && chargify_customer_id.nil?
+    errors.messages[:email] && errors.messages[:email].include?("has already been taken") && !current?
   end
 
   def badge_class

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -149,6 +149,10 @@ class Member < ActiveRecord::Base
     end
   end
 
+  def abandoned_signup?
+    errors.messages[:email] && errors.messages[:email].include?("has already been taken") && chargify_customer_id.nil?
+  end
+
   def badge_class
     if %w[partner sponsor].include?(product_name)
       "partner"

--- a/features/signup.feature
+++ b/features/signup.feature
@@ -128,6 +128,22 @@ Feature: Add new signups to queue
     And my details should be queued for further processing
     When chargify verifies the payment
 
+  Scenario: User tries to sign up with an email that has an abandonned account, but passwords don't match
+    Given there is an abandoned account with the email "test@foo.bar" and the password "p4ssw0rd"
+    And I try to sign up with the email "test@foo.bar" and the password "s3cr3tc0d3z"
+    When I click sign up
+    Then I should be redirected to the login page
+    And I should see an error telling me I need to login
+    And I log in
+    Then I am redirected to the payment page
+    And I am processed through chargify for the "corporate-supporter_annual" option
+    When I click pay now
+    And am returned to the thanks page
+    And a welcome email should be sent to me
+    And I should see "Welcome Pack" in the email body
+    And my details should be queued for further processing
+    When chargify verifies the payment
+
   @javascript
   Scenario: Auto-update terms based on user input
 

--- a/features/signup.feature
+++ b/features/signup.feature
@@ -65,7 +65,7 @@ Feature: Add new signups to queue
     When I click pay now
 
   Scenario Outline: Member tries to sign up, but misses a mandatory field
-    
+
     When I enter my name and contact details
     And I enter my company details
     And I enter my address details
@@ -95,7 +95,7 @@ Feature: Add new signups to queue
     Then I should get an error telling me to accept the terms
 
   Scenario: Member tries to sign up, but their password doesn't match
-  
+
     When I enter my name and contact details
     And I enter my company details
     And I enter my address details
@@ -113,6 +113,20 @@ Feature: Add new signups to queue
     And I agree to the terms
     When I click sign up
     Then I should see an error relating to Organisation name
+
+  Scenario: Member abandons signup before chargify processes, and returns to sign up again
+
+    Given I have signed up, but haven't paid
+    And I should have a membership number generated
+    And I try to sign up again
+    Then I am redirected to the payment page
+    And I am processed through chargify for the "corporate-supporter_annual" option
+    When I click pay now
+    And am returned to the thanks page
+    And a welcome email should be sent to me
+    And I should see "Welcome Pack" in the email body
+    And my details should be queued for further processing
+    When chargify verifies the payment
 
   @javascript
   Scenario: Auto-update terms based on user input

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -50,15 +50,15 @@ end
 
 When /^I enter my name and contact details$/ do
   @contact_name = 'Ian McIain'
-  @email = 'iain@foobar.com'
+  @email ||= 'iain@foobar.com'
   @telephone = '0121 123 446'
 
   fill_in('member_contact_name', :with => @contact_name)
   fill_in('member_email', :with => @email)
   fill_in('member_telephone', :with => @telephone)
 
-  fill_in('member_password', :with => 'p4ssw0rd')
-  fill_in('member_password_confirmation', :with => 'p4ssw0rd')
+  fill_in('member_password', :with => @password || 'p4ssw0rd')
+  fill_in('member_password_confirmation', :with => @password || 'p4ssw0rd')
 end
 
 When /^I enter my address details$/ do
@@ -374,4 +374,45 @@ Given(/^I try to sign up again$/) do
     And I agree to the terms
     And I click sign up
   }
+end
+
+
+Given(/^there is an abandoned account with the email "(.*?)" and the password "(.*?)"$/) do |email, password|
+  @email = email
+  @password = password
+  @original_password = password
+  steps %{
+    When I visit the signup page
+    And I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+    And I click sign up
+  }
+  @membership_number = Member.last.membership_number
+end
+
+Given(/^I try to sign up with the email "(.*?)" and the password "(.*?)"$/) do |email, password|
+  @email = email
+  @password = password
+  steps %{
+    When I visit the signup page
+    And I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+  }
+end
+
+Then(/^I should be redirected to the login page$/) do
+  expect(current_path).to eq(new_member_session_path)
+end
+
+Then(/^I should see an error telling me I need to login$/) do
+  expect(page.body).to include("You have already started the signup process, to continue to payment, please login.")
+end
+
+Then(/^I log in$/) do
+  fill_in('member_password', :with => @original_password)
+  click_button('submit')
 end

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -193,7 +193,7 @@ end
 Then /^am returned to the thanks page$/ do
   member = Member.find_by_email(@email)
   expect(current_path).to eq(thanks_member_path(member))
-end 
+end
 
 Then /^there are payment frequency options$/ do
   expect(page).to have_css("input[type=radio][id=payment_frequency_monthly][value=monthly]")
@@ -351,4 +351,27 @@ end
 Then(/^I should have an origin of "(.*?)"$/) do |origin|
   member = Member.find_by_email(@email)
   expect(member.origin).to eq(origin)
+end
+
+Given(/^I have signed up, but haven't paid$/) do
+  steps %{
+    When I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+    And I click sign up
+  }
+end
+
+Given(/^I try to sign up again$/) do
+  steps %{
+    Given that I want to sign up as a supporter
+    And product information has been setup for "corporate-supporter_annual"
+    When I visit the signup page
+    When I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+    And I click sign up
+  }
 end


### PR DESCRIPTION
For https://github.com/theodi/shared/issues/625.

If a user tries to signup with the same password again, they are redirected directly to the payment page. If the password differs in any way, as an extra level of security, we redirect the user to the login page, where they can sign in again, or reset their password.