### PR TITLE
Allow payment via invoice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ gem 'zeroclipboard-rails'
 
 # To use debugger
 # gem 'debugger'
+gem 'mysql2'
 
 
 group :development, :test do
@@ -98,5 +99,4 @@ end
 group :production do
   gem 'foreman', '< 0.65.0'
   gem 'thin'
-  gem 'mysql2'
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -89,6 +89,10 @@ class MembersController < ApplicationController
 
   def thanks
     @title = "Thanks for supporting The ODI"
+    if current_member.invoice === true && current_member.product_name == "supporter"
+      current_member.send(:add_to_capsule)
+      current_member.deliver_welcome_email!
+    end
   end
 
   def payment

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -90,8 +90,7 @@ class MembersController < ApplicationController
   def thanks
     @title = "Thanks for supporting The ODI"
     if current_member.invoiced_member?
-      current_member.send(:add_to_capsule)
-      current_member.deliver_welcome_email!
+      current_member.process_invoiced_member!
     end
   end
 

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -89,7 +89,7 @@ class MembersController < ApplicationController
 
   def thanks
     @title = "Thanks for supporting The ODI"
-    if current_member.invoice === true && current_member.product_name == "supporter"
+    if current_member.invoiced_member?
       current_member.send(:add_to_capsule)
       current_member.deliver_welcome_email!
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -57,7 +57,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    if resource.invoice === true
+    if resource.invoice === true && resource.product_name == "supporter"
       thanks_member_path(resource)
     else
       payment_member_path(resource, coupon: params[:coupon].presence)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -57,7 +57,11 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    payment_member_path(resource, coupon: params[:coupon].presence)
+    if resource.invoice === true
+      thanks_member_path(resource)
+    else
+      payment_member_path(resource, coupon: params[:coupon].presence)
+    end
   end
 
   def check_product_name

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -57,7 +57,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    if resource.invoice === true && resource.product_name == "supporter"
+    if resource.invoiced_member?
       thanks_member_path(resource)
     else
       payment_member_path(resource, coupon: params[:coupon].presence)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -57,7 +57,8 @@ class Member < ActiveRecord::Base
                   :agreed_to_terms,
                   :address,
                   :origin,
-                  :coupon
+                  :coupon,
+                  :invoice
 
   attr_accessor :agreed_to_terms
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -113,6 +113,11 @@ class Member < ActiveRecord::Base
     send_devise_notification(:confirmation_instructions)
   end
 
+  def process_invoiced_member!
+    add_to_capsule
+    deliver_welcome_email!
+  end
+
   def check_organization_names
     if new_record? # Only validate on create
       unless Organization.where(:name => organization_name).empty?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -155,6 +155,10 @@ class Member < ActiveRecord::Base
     errors.messages[:email] && errors.messages[:email].include?("has already been taken") && !current?
   end
 
+  def invoiced_member?
+    self.invoice === true && self.product_name == "supporter"
+  end
+
   def badge_class
     if %w[partner sponsor].include?(product_name)
       "partner"

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -114,6 +114,7 @@ class Member < ActiveRecord::Base
   end
 
   def process_invoiced_member!
+    current!
     add_to_capsule
     deliver_welcome_email!
   end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,6 +9,8 @@
 
   <%= f.hidden_field :coupon, value: params[:coupon] if params[:coupon].present? %>
   <%= f.hidden_field :origin, value: params[:origin] if params[:origin].present? %>
+  <%= f.hidden_field :invoice, value: 1 if params[:invoice].present? %>
+
   <%= f.hidden_field :product_name %>
 
   <%= render :partial => 'member_details', :locals => { :f => f } %>

--- a/db/migrate/20150609084647_add_invoice_flag_to_member.rb
+++ b/db/migrate/20150609084647_add_invoice_flag_to_member.rb
@@ -1,0 +1,5 @@
+class AddInvoiceFlagToMember < ActiveRecord::Migration
+  def change
+    add_column :members, :invoice, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150520144034) do
+ActiveRecord::Schema.define(:version => 20150609084647) do
 
   create_table "admins", :force => true do |t|
     t.string   "email",              :default => "", :null => false
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(:version => 20150520144034) do
     t.string   "origin",                                   :default => "odihq",  :null => false
     t.string   "payment_frequency",                        :default => "annual", :null => false
     t.string   "coupon"
+    t.boolean  "invoice",                                  :default => false
   end
 
   add_index "members", ["email"], :name => "index_members_on_email", :unique => true
@@ -103,7 +104,7 @@ ActiveRecord::Schema.define(:version => 20150520144034) do
     t.integer  "item"
     t.string   "table"
     t.integer  "month",      :limit => 2
-    t.integer  "year",       :limit => 5
+    t.integer  "year",       :limit => 8
     t.datetime "created_at",              :null => false
     t.datetime "updated_at",              :null => false
   end

--- a/features/signup_with_invoice.feature
+++ b/features/signup_with_invoice.feature
@@ -15,9 +15,11 @@ Feature: Signup and pay by invoice
     And I enter my company details
     And I enter my address details
     And I agree to the terms
+    Then my details should be queued for further processing
     When I click sign up
     Then I am returned to the thanks page
     And I should have a membership number generated
+    And a welcome email should be sent to me
 
   Scenario: Individual member setting invoice flag still gets redirected to chargify
     Given I want to sign up as an individual member

--- a/features/signup_with_invoice.feature
+++ b/features/signup_with_invoice.feature
@@ -20,6 +20,7 @@ Feature: Signup and pay by invoice
     Then I am returned to the thanks page
     And I should have a membership number generated
     And a welcome email should be sent to me
+    And I should be marked as active
 
   Scenario: Individual member setting invoice flag still gets redirected to chargify
     Given I want to sign up as an individual member

--- a/features/signup_with_invoice.feature
+++ b/features/signup_with_invoice.feature
@@ -8,3 +8,13 @@ Feature: Signup and pay by invoice
     When I visit the signup page with the invoice flag set
     Then the signup page should have a hidden field called "invoice"
     And the hidden field should have the value "1"
+
+  Scenario: Member signing up with invoice does not get redirected to chargify
+    When I visit the signup page with the invoice flag set
+    And I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+    When I click sign up
+    Then I am returned to the thanks page
+    And I should have a membership number generated

--- a/features/signup_with_invoice.feature
+++ b/features/signup_with_invoice.feature
@@ -18,3 +18,13 @@ Feature: Signup and pay by invoice
     When I click sign up
     Then I am returned to the thanks page
     And I should have a membership number generated
+
+  Scenario: Individual member setting invoice flag still gets redirected to chargify
+    Given I want to sign up as an individual member
+    And product information has been setup for "individual-supporter"
+    When I visit the signup page with the invoice flag set
+    When I enter my name and contact details
+    And I enter my address details
+    And I agree to the terms
+    When I click sign up
+    Then I am redirected to the payment page

--- a/features/signup_with_invoice.feature
+++ b/features/signup_with_invoice.feature
@@ -1,0 +1,10 @@
+Feature: Signup and pay by invoice
+
+  Background:
+    Given that I want to sign up as a supporter
+    And product information has been setup for "corporate-supporter_annual"
+
+  Scenario: Member visits the signup page with invoice flag set
+    When I visit the signup page with the invoice flag set
+    Then the signup page should have a hidden field called "invoice"
+    And the hidden field should have the value "1"

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -436,3 +436,8 @@ end
 Then(/^the hidden field should have the value "(.*?)"$/) do |value|
   expect(@field.value).to eq(value)
 end
+
+Then(/^I should be marked as active$/) do
+  expect(@member.cached_active).to eq(true)
+  expect(@member.current).to eq(true)
+end

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -196,7 +196,7 @@ Then /^I am redirected to the payment page$/ do
   expect(current_path).to eq(payment_member_path(member))
 end
 
-Then /^am returned to the thanks page$/ do
+Then /^I ?am returned to the thanks page$/ do
   member = Member.find_by_email(@email)
   expect(current_path).to eq(thanks_member_path(member))
 end

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -48,6 +48,12 @@ When /^I visit the signup page$/ do
   @field_prefix = 'member'
 end
 
+When(/^I visit the signup page with the invoice flag set$/) do
+  visit("/members/new?level=#{@product_name}&invoice=true")
+  expect(page).to have_content 'Become an ODI member'
+  @field_prefix = 'member'
+end
+
 When /^I enter my name and contact details$/ do
   @contact_name = 'Ian McIain'
   @email ||= 'iain@foobar.com'
@@ -420,4 +426,13 @@ end
 Then(/^I log in$/) do
   fill_in('member_password', :with => @original_password)
   click_button('submit')
+end
+
+Then(/^the signup page should have a hidden field called "(.*?)"$/) do |name|
+  expect(page).to have_selector("input[name='member[#{name}]']")
+  @field = page.find("input[name='member[#{name}]']")
+end
+
+Then(/^the hidden field should have the value "(.*?)"$/) do |value|
+  expect(@field.value).to eq(value)
 end


### PR DESCRIPTION
Needed for #413 

This allows the membership team to give a user a special link to be able to sign up via invoice. This will bypass Chargify, queue everything in the usual way and send an email. 

Then the membership team can then take the Xero invoice out of draft and send it to the member. Once it's paid, they can set the user to active in Capsule and they'll appear in the directory once the sync happens.

Sound legit @greenreveller?