### PR TITLE
Retain invoice flag after redirect happens

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,7 @@
 
   <%= f.hidden_field :coupon, value: params[:coupon] if params[:coupon].present? %>
   <%= f.hidden_field :origin, value: params[:origin] if params[:origin].present? %>
-  <%= f.hidden_field :invoice, value: 1 if params[:invoice].present? %>
+  <%= f.hidden_field :invoice, value: 1 if params[:invoice].present? || @member.invoice == true %>
 
   <%= f.hidden_field :product_name %>
 

--- a/features/signup_with_invoice.feature
+++ b/features/signup_with_invoice.feature
@@ -31,3 +31,20 @@ Feature: Signup and pay by invoice
     And I agree to the terms
     When I click sign up
     Then I am redirected to the payment page
+
+  Scenario: Member signing up with invoice retains invoive flag on redirect
+    When I visit the signup page with the invoice flag set
+    And I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+    But I leave contact_name blank
+    And I click sign up
+    Then I should see an error relating to Your name
+    And I enter my name and contact details
+    Then my details should be queued for further processing
+    When I click sign up
+    And I am returned to the thanks page
+    And I should have a membership number generated
+    And a welcome email should be sent to me
+    And I should be marked as active


### PR DESCRIPTION
So, users were still getting redirected to Chargify after redirect, but this was because they were putting too short a password in, getting redirected to the form, and the invoice flag was getting lost. This was driving me round the bend, but now I have it.