### PR TITLE
Add new student product

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GIT
 
 GIT
   remote: git://github.com/theodi/open-orgn-services.git
-  revision: 05f6e688059cbe78030eb77179e944d78f9038fa
+  revision: 38bbdf73c4a7dffb6486f6cded9d2a19c95cd2c3
   specs:
     open-orgn-services (0.1.3)
       activemodel (~> 3.2, >= 3.2.12)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(resource_or_scope)
-    if resource_or_scope == :member && (current_member.individual? || !current_member.cached_active)
+    if resource_or_scope == :member && current_member && (current_member.individual? || !current_member.cached_active)
       root_path
     else
       request.referrer || root_path

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationsController < Devise::RegistrationsController
   before_filter :check_product_name, :only => 'new'
   before_filter :set_title, :only => %w[new create]
-  helper_method :individual?
+  helper_method :individual?, :student?
 
   # copied from https://github.com/plataformatec/devise/blob/v2.2.8/app/controllers/devise/registrations_controller.rb
   # because can't use super as that would cause a double render
@@ -75,6 +75,10 @@ class RegistrationsController < Devise::RegistrationsController
 
   def individual?
     resource.individual?
+  end
+
+  def student?
+    resource.student?
   end
 
   def sign_up_params

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -53,11 +53,15 @@ module MembersHelper
     content_tag(:li, content, class: ('active' if active))
   end
 
-  def payment_button_label(discount_type)
-    if discount_type == :free
-      "Enter card details"
+  def payment_button_label(member, discount_type)
+    if member.student?
+      "Complete"
     else
-      "Pay now"
+      if discount_type == :free
+        "Enter card details"
+      else
+        "Pay now"
+      end
     end
   end
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -12,7 +12,7 @@ class DeviseMailer < Devise::Mailer
 
   def confirmation_instructions(record, opts)
     @type = "capsule" if opts[:capsule].present?
-    if record.individual?
+    if record.individual? || record.student?
       document_renderer = DocumentRenderer.new
       attachments.inline['supporter.png'] = {
         mime_type: 'image/png',
@@ -25,5 +25,5 @@ class DeviseMailer < Devise::Mailer
     end
     super
   end
-
 end
+

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -11,6 +11,7 @@ class Member < ActiveRecord::Base
     partner
     sponsor
     individual
+    student
   ]
 
   CURRENT_SUPPORTER_LEVELS = %w[
@@ -137,7 +138,7 @@ class Member < ActiveRecord::Base
   validates :postal_code, presence: true, on: :create
   validates_acceptance_of :agreed_to_terms, on: :create
 
-  validates_with OrganizationValidator, on: :create, unless: :individual?
+  validates_with OrganizationValidator, on: :create, unless: Proc.new { |member| member.individual? || member.student? }
 
   scope :current, where(:current => true)
   scope :valid, where('product_name is not null')
@@ -263,6 +264,10 @@ class Member < ActiveRecord::Base
 
   def individual?
     self.class.is_individual_level?(product_name)
+  end
+
+  def student?
+    product_name == "student"
   end
 
   def organization?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -395,7 +395,7 @@ class Member < ActiveRecord::Base
   def get_plan_description
     {
       'individual-supporter'         => 'Individual Supporter',
-      'individual-supporter-student' => 'Individual Student Supporter',
+      'individual-supporter-student' => 'ODI Student Supporter',
       'corporate-supporter_annual'   => 'Corporate Supporter',
       'supporter_annual'             => 'Supporter',
       'supporter_monthly'            => 'Supporter'

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -16,6 +16,7 @@ class Member < ActiveRecord::Base
   CURRENT_SUPPORTER_LEVELS = %w[
     supporter
     individual
+    student
   ]
 
   ORGANISATION_TYPES = {

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -400,7 +400,10 @@ class Member < ActiveRecord::Base
   end
 
   def get_plan_price
-    amount = CHARGIFY_PRODUCT_PRICES[get_plan]
+    amount = CHARGIFY_PRODUCT_PRICES.fetch(get_plan) do
+      raise RuntimeError, "Can't get product price for plan '#{get_plan}'. Does it exist in Chargify?"
+    end
+
     if address_country == 'GB'
       if individual?
         inc_vat, vat = amount * 1.2, amount * 0.2

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -331,6 +331,8 @@ class Member < ActiveRecord::Base
       'Founding partner'
     elsif organization?
       product_name.titleize
+    elsif student?
+      "Student Supporter"
     else
       "Supporter"
     end
@@ -392,10 +394,11 @@ class Member < ActiveRecord::Base
 
   def get_plan_description
     {
-      'individual-supporter'            => 'Individual Supporter',
-      'corporate-supporter_annual' => 'Corporate Supporter',
-      'supporter_annual'                => 'Supporter',
-      'supporter_monthly'                => 'Supporter'
+      'individual-supporter'         => 'Individual Supporter',
+      'individual-supporter-student' => 'Individual Student Supporter',
+      'corporate-supporter_annual'   => 'Corporate Supporter',
+      'supporter_annual'             => 'Supporter',
+      'supporter_monthly'            => 'Supporter'
     }[get_plan]
   end
 
@@ -405,7 +408,7 @@ class Member < ActiveRecord::Base
     end
 
     if address_country == 'GB'
-      if individual?
+      if individual? || student?
         inc_vat, vat = amount * 1.2, amount * 0.2
         "£%.2f including £%.2f VAT" % [inc_vat, vat]
       else
@@ -543,7 +546,9 @@ class Member < ActiveRecord::Base
   end
 
   def setup_organization
-    self.create_organization(:name => organization_name) unless individual?
+    return if individual? || student?
+
+    self.create_organization(:name => organization_name)
   end
 
   def country_name

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -440,6 +440,8 @@ class Member < ActiveRecord::Base
   def get_plan
     if individual?
       'individual-supporter'
+    elsif student?
+      'individual-supporter-student'
     else
       if large_corporate_organization?
         'corporate-supporter_annual'

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -437,6 +437,20 @@ class Member < ActiveRecord::Base
     self.invoice == true
   end
 
+  def get_plan
+    if individual?
+      'individual-supporter'
+    else
+      if large_corporate_organization?
+        'corporate-supporter_annual'
+      elsif payment_frequency == 'monthly'
+        'supporter_monthly'
+      else
+        'supporter_annual'
+      end
+    end
+  end
+
   private
 
   def generate_membership_number
@@ -528,20 +542,6 @@ class Member < ActiveRecord::Base
 
   def setup_organization
     self.create_organization(:name => organization_name) unless individual?
-  end
-
-  def get_plan
-    if individual?
-      'individual-supporter'
-    else
-      if large_corporate_organization?
-        'corporate-supporter_annual'
-      elsif payment_frequency == 'monthly'
-        'supporter_monthly'
-      else
-        'supporter_annual'
-      end
-    end
   end
 
   def country_name

--- a/app/views/devise/registrations/_member_details.html.erb
+++ b/app/views/devise/registrations/_member_details.html.erb
@@ -17,7 +17,7 @@
   	</div>
   </div>
 
-  <% unless individual? %>
+  <% unless individual? || student? %>
     <div class="control-group">
     	<%= f.label :organization_name, :class => 'control-label' %>
     	<div class="controls">
@@ -61,7 +61,7 @@
 
 </fieldset>
 
-<% unless individual? %>
+<% unless individual? || student? %>
   <fieldset>
 
     <legend>Financial information</legend>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -60,7 +60,7 @@
   <% end %>
   <script>
     function update_name() {
-      <% if individual? %>
+      <% if individual? || student? %>
       $('.legal-name').text($('#member_contact_name')[0].value);
       <% else %>
       $('.legal-name').text($('#member_organization_name')[0].value);

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -47,13 +47,13 @@
 
   	<p>
       Please read the terms and conditions below and tick to say you accept them.
-      <% unless individual? %>
+      <% unless individual? || student? %>
         As an open organisation we publish who funds us and what our relationships are. As part of this agreement you are agreeing that we can publish your membership and our contract.
       <% end %>
     </p>
 
 <div id="terms" class="well">
-  <% if individual? %>
+  <% if individual? || student? %>
     <%= render :partial => 'individual_terms', :locals => {:member => PlaceholderPresenter.new} %>
   <% else %>
     <%= render :partial => 'terms', :locals => {:member => PlaceholderPresenter.new} %>
@@ -113,7 +113,7 @@
     <p>
     <%= f.submit "Become an ODI member", :id => 'submit', :class => 'btn btn-primary btn-large' %>
     </p>
-    <% if individual? %>
+    <% if individual? || student? %>
       <p>You have the <%= link_to 'right to cancel', right_to_cancel_members_path %> within the first 14 days of your membership.</p>
     <% end %>
   </div>

--- a/app/views/devise_mailer/_student_confirmation.html.erb
+++ b/app/views/devise_mailer/_student_confirmation.html.erb
@@ -1,0 +1,64 @@
+<p>Dear Student,</p>
+
+<p>We are delighted to welcome you to the Open Data Institute member network. As an ODI Supporter you join a unique group of individuals and organisations who share a deep interest in open data and its potential.</p>
+
+<p>As you share your perspectives, collaborate with your fellow members and support the ODI you will play a key role in helping us to achieve our mission to promote a sustainable open data culture around the world.</p>
+
+<table>
+    <tr>
+        <td>
+            <ul>
+                <li>Your membership number is <strong><%= @resource.membership_number %></strong></li>
+                <% if @resource.reset_password_token %>
+                  <li>To activate your account click <%= link_to 'here', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token) %></li>
+                <% else %>
+                  <li>Sign in to your account <%= link_to 'here', new_member_session_url(membership_number: @resource.membership_number) %></li>
+                <% end %>
+
+                <li>You will then be able to download an ODI Supporter badge which you can display on your website and on your print collateral</li>
+            </ul>
+        </td>
+        <td>
+            <%= image_tag attachments['supporter.png'].url, width: 116, height: 100, alt: "" %>
+        </td>
+    </tr>
+</table>
+
+<p>As an ODI Individual Supporter we hope you will also:</p>
+
+<h3>Connect and collaborate</h3>
+
+<p>Connect with our global network of corporates, startups, universities and public sector organisations by joining the <%= link_to "LinkedIn members' group", "https://www.linkedin.com/groups?gid=5161407" %>. For the latest on open data events and news follow <%= link_to '@ODIHQmembers', 'https://twitter.com/ODIHQmembers' %> and <%= link_to '@ODIHQ', 'https://twitter.com/ODIHQ' %> on Twitter.</p>
+
+<h3>Stay ahead of the curve</h3>
+
+<p>We’ll be pinging you through the membership e-newsletter every month and and you’ll also receive priority notification of ODI Summit discounts and selected access to other ODI events.</p>
+
+<h3>Boost your skills</h3>
+
+<p>As an ODI Supporter, you can claim an exclusive 20% discount on Open Data Institute training. Whether you’re interested in law, business or finding stories in open data, browse our specialist <%= link_to 'public training courses', 'http://theodi.org/courses' %> and book your place by selecting an ‘ODI Member’ ticket on the course page.</p>
+
+<h3>Get inspired</h3>
+
+<p>The ODI holds free, <%= link_to 'Friday lunchtime lectures', 'http://theodi.org/lunchtime-lectures' %> every week that showcase the many ways that open data is changing the world. If you’re nearby, come along and bring your lunch, or if not you can tune into the live audio stream. If you’d like to suggest a speaker for one of our lectures, get in touch with the <%= link_to 'membership team', 'mailto:members@theodi.org' %>. You can find out what else we have coming up on our <%= link_to 'events page', 'http://theodi.org/events' %>.</p>
+
+<h3>Broaden your horizons</h3>
+
+<p>If you want to learn more about open data, take a look at our <%= link_to 'case studies', 'http://theodi.org/case-studies' %>, technical open data <%= link_to 'guides', 'http://theodi.org/guides' %>, the ODI <%= link_to 'lecture archive', 'http://theodi.org/lunchtime-lectures' %> and our latest news and <%= link_to 'video content', 'http://vimeo.com/theodiuk' %>.</p>
+
+<p>Your membership officially runs from <%= Date.today.to_formatted_s(:long_ordinal) %> to <%= (Date.yesterday + 1.year).to_formatted_s(:long_ordinal) %> and costs £108 (£90 + VAT). Your membership terms and conditions are attached to this email. If you’ve changed your mind then you have the <%= link_to 'right to cancel', 'http://bit.ly/ODIcancellation' %> within the first 14 days from the start of your membership.</p>
+
+<p>We’ll get in touch one month before your membership is due to expire and invite you to renew for another year. We hope that you will enjoy being an ODI Supporter and that you’ll stay a part of our global network for the years to come.</p>
+
+<p>If you have any questions or suggestions, please do get in touch by emailing <%= link_to 'members@theodi.org', 'mailto:members@theodi.org' %>.</p>
+
+<p>Best wishes,<br />
+<br />
+The ODI Membership team<br />
+<br />
+Open Data Institute<br />
+3rd Floor, 65 Clifton Street, London, EC2A 4JE<br />
+Company number 08030289<br />
+members@theodi.org
+</p>
+

--- a/app/views/devise_mailer/confirmation_instructions.html.erb
+++ b/app/views/devise_mailer/confirmation_instructions.html.erb
@@ -1,5 +1,7 @@
 <% if @resource.individual? %>
   <%= render(:partial => 'individual_confirmation') %>
+<% elsif @resource.student? %>
+  <%= render(:partial => 'student_confirmation') %>
 <% else %>
   <%= render(:partial => 'confirmation') %>
 <% end %>

--- a/app/views/members/payment.html.erb
+++ b/app/views/members/payment.html.erb
@@ -1,5 +1,9 @@
 <p class="lead">
-To complete your registration, please continue to the payment page.
+  <% if @member.student? %>
+    To complete your registration, please continue to the next page.
+  <% else %>
+    To complete your registration, please continue to the payment page.
+  <% end %>
 </p>
 
 <% case @discount_type %>

--- a/app/views/members/payment.html.erb
+++ b/app/views/members/payment.html.erb
@@ -20,7 +20,13 @@ To complete your registration, please continue to the payment page.
     discount will be applied on the next page.
 </p>
 <% else %>
-<p>Being <%= indefinite_article(@member.get_plan_description) %> is <%= @member.get_plan_price %> per year.</p>
+
+  <% if @member.student? %>
+    <p>Being <%= indefinite_article(@member.get_plan_description) %> is FREE!</p>
+  <% else %>
+    <p>Being <%= indefinite_article(@member.get_plan_description) %> is <%= @member.get_plan_price %> per year.</p>
+  <% end %>
+
 <% end %>
 
 <p>
@@ -47,7 +53,7 @@ To complete your registration, please continue to the payment page.
   <% end %>
   <div class="control-group">
     <div class="controls">
-      <input type="submit" class="btn btn-primary btn-large" value="<%= payment_button_label(@discount_type) %>">
+      <input type="submit" class="btn btn-primary btn-large" value="<%= payment_button_label(@member, @discount_type) %>">
     </div>
   </div>
 <% end %>

--- a/features/signup_as_student.feature
+++ b/features/signup_as_student.feature
@@ -1,0 +1,36 @@
+Feature: Signup as an student member
+
+  Background:
+    Given I want to sign up as an student member
+    And product information has been setup for "individual-supporter-student"
+    When I visit the signup page
+
+  Scenario: Signup as a student supporter
+    When I enter my name and contact details
+    And I enter my address details
+    Then I should not be asked for financial information
+    And I should not be asked for organization details
+    And I agree to the terms
+    When I click sign up
+    Then I am redirected to the payment page
+    And I should have a membership number generated
+    And I am processed through chargify for the "individual-supporter-student" option
+    When I click complete
+    And I am returned to the thanks page
+    And I should not have an organisation assigned to me
+    And a welcome email should be sent to me
+    And I should see "Dear Student" in the email body
+    And I should see "We are delighted to welcome you to the Open Data Institute member network" in the email body
+    And I should see "download an ODI Supporter badge" in the email body
+    And my details should be queued for further processing
+    When chargify verifies the payment
+
+  @javascript
+  Scenario: Auto-update terms based on user input
+    Given I want to sign up as an student member
+    When I visit the signup page
+    And I enter my name and contact details
+    And I enter my address details
+    Then I should see "You agree to comply with these terms and conditions"
+    And I should see "means Ian McIain of 123 Fake Street, Faketown, Fakeshire, United Kingdom, FAKE 123"
+

--- a/features/step_definitions/signup_as_student_steps.rb
+++ b/features/step_definitions/signup_as_student_steps.rb
@@ -1,0 +1,23 @@
+Given(/^I want to sign up as an student member$/) do
+  @product_name = 'student'
+  @payment_method = 'credit_card'
+  @payment_ref = /cus_[0-9A-Za-z]{14}/
+end
+
+Then(/^I should not be asked for organization details$/) do
+  steps %{
+    Then I should not see the "Organisation Name" field
+    And I should not see the "Organisation size" field
+    And I should not see the "Organisation type" field
+    And I should not see the "Industry sector" field
+    And I should not see the "Company Number" field
+  }
+end
+
+Then(/^I should not be asked for financial information$/) do
+  steps %{
+    And I should not see the "VAT Number (if not UK)" field
+    And I should not see the "Purchase Order Number" field
+  }
+end
+

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -156,6 +156,10 @@ When /^I click pay now$/ do
   click_button('Pay now')
 end
 
+When /^I click complete$/ do
+  click_button('Complete')
+end
+
 Then /^I am redirected to the payment page$/ do
   member = Member.find_by_email(@email)
   expect(current_path).to eq(payment_member_path(member))

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -5,14 +5,14 @@ describe RegistrationsController do
   before :each do
     request.env['devise.mapping'] = Devise.mappings[:member]
   end
-  
+
   %w[supporter individual student].each do |level|
-    it "does not allow a level of #{level}" do
+    it "does allow a level of #{level}" do
       get :new, :level => level
       expect(response).to be_success
     end
   end
-  
+
   %w[member partner sponsor spaceman].each do |level|
     it "does not allow a level of #{level}" do
       get :new, :level => level
@@ -20,7 +20,7 @@ describe RegistrationsController do
       expect(response).to redirect_to('http://www.theodi.org/join-us')
     end
   end
-  
+
   it 'should redirect back to join us page for no level' do
     get :new
     expect(response).to be_redirect
@@ -91,5 +91,5 @@ describe RegistrationsController do
       expect(member.origin).to eq('odi-leeds')
     end
   end
-
 end
+

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -6,7 +6,7 @@ describe RegistrationsController do
     request.env['devise.mapping'] = Devise.mappings[:member]
   end
   
-  %w[supporter individual].each do |level|
+  %w[supporter individual student].each do |level|
     it "does not allow a level of #{level}" do
       get :new, :level => level
       expect(response).to be_success

--- a/spec/helpers/members_helper_spec.rb
+++ b/spec/helpers/members_helper_spec.rb
@@ -12,19 +12,31 @@ require 'spec_helper'
 # end
 describe MembersHelper do
   describe "#payment_button_label" do
+    let(:member) { double(student?: false) }
+
     context "type if free" do
       it "asks you to enter your card details" do
         discount_type = :free
 
-        expect(helper.payment_button_label(discount_type)).to eq("Enter card details")
+        expect(helper.payment_button_label(member, discount_type)).to eq("Enter card details")
       end
     end
 
-    context "type if not free" do
+    context "type is not free" do
       it "asks you to pay now" do
         discount_type = :not_free
 
-        expect(helper.payment_button_label(discount_type)).to eq("Pay now")
+        expect(helper.payment_button_label(member, discount_type)).to eq("Pay now")
+      end
+    end
+
+    context "the member is a student?" do
+      let(:member) { double(student?: true) }
+
+      it "asks you to 'Complete' the process" do
+        discount_type = :anything
+
+        expect(helper.payment_button_label(member, discount_type)).to eq("Complete")
       end
     end
   end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -226,6 +226,14 @@ describe Member do
       end
     end
 
+    context "member is student" do
+      it "returns 'individual-supporter-student'" do
+        member = Member.new(product_name: "student")
+
+        expect(member.get_plan).to eq("individual-supporter-student")
+      end
+    end
+
     context "member is a large corporate organization" do
       it "returns 'corporate-supporter_annual'" do
         member = Member.new

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -26,7 +26,7 @@ describe Member do
 
   context "creating a member" do
     %w[organization_name organization_size organization_type organization_sector].each do |name|
-      it "requires an organisation name" do
+      it "requires an #{name}" do
         (member = Member.new).valid?
         expect(member.errors[name.to_sym]).to include("can't be blank")
       end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -208,6 +208,13 @@ describe Member do
       expect(m.get_monthly_plan_price).to eq("£60.00 + VAT")
     end
 
+    it 'raises an error if a plan price cannot be found' do
+      m = Member.new
+      # Not ideal, but a necessity at the moment
+      allow(m).to receive(:get_plan).and_return('plan-that-is-not-in-chargify')
+
+      expect { m.get_plan_price }.to raise_error(RuntimeError, /Can't get product price for plan 'plan-that-is-not-in-chargify'\. Does it exist in Chargify\?/)
+    end
   end
 
   describe 'chargify redirect link' do

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -61,6 +61,14 @@ describe Member do
       organization_errors = member.errors.select {|k,_| k.to_s.starts_with?('organization_') }
       expect(organization_errors).to be_empty
     end
+
+    it "does not need organization details for an student" do
+      member = Member.new(product_name: 'student')
+      member.save
+
+      organization_errors = member.errors.select {|k,_| k.to_s.starts_with?('organization_') }
+      expect(organization_errors).to be_empty
+    end
   end
 
   context "updating a member" do

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -217,6 +217,44 @@ describe Member do
     end
   end
 
+  describe "#get_plan" do
+    context "member is individual" do
+      it "returns 'individual-supporter'" do
+        member = Member.new(product_name: "individual")
+
+        expect(member.get_plan).to eq("individual-supporter")
+      end
+    end
+
+    context "member is a large corporate organization" do
+      it "returns 'corporate-supporter_annual'" do
+        member = Member.new
+        member.organization_type = "commercial"
+        member.organization_size = ">1000"
+
+        expect(member.get_plan).to eq("corporate-supporter_annual")
+      end
+    end
+
+    context "member is a supporter who pays monthly" do
+      it "returns 'supporter_monthly'" do
+        member = Member.new(product_name: "supporter")
+        member.payment_frequency = "monthly"
+
+        expect(member.get_plan).to eq("supporter_monthly")
+      end
+    end
+
+    context "member is a supporter who pays annually" do
+      it "returns 'supporter_annual" do
+        member = Member.new(product_name: "supporter")
+        member.payment_frequency = nil
+
+        expect(member.get_plan).to eq("supporter_annual")
+      end
+    end
+  end
+
   describe 'chargify redirect link' do
     before do
       Member.register_chargify_product_link('individual-supporter', 'https://chargify.com/individual')

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -56,6 +56,8 @@ describe Member do
 
     it "does not need organization details for an individual" do
       member = Member.new(product_name: 'individual')
+      member.save
+
       organization_errors = member.errors.select {|k,_| k.to_s.starts_with?('organization_') }
       expect(organization_errors).to be_empty
     end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -177,6 +177,8 @@ describe Member do
     before do
       Member.register_chargify_product_link('individual-supporter', 'https://chargify.com/individiual')
       Member.register_chargify_product_price('individual-supporter', 9000)
+      Member.register_chargify_product_link('individual-supporter-student', 'https://chargify.com/student')
+      Member.register_chargify_product_price('individual-supporter-student', 9000)
       Member.register_chargify_product_link('supporter_annual', 'https://chargify.com/non-profit')
       Member.register_chargify_product_price('supporter_annual', 72000)
       Member.register_chargify_product_link('supporter_monthly', 'https://chargify.com/monthly-non-profit')
@@ -195,6 +197,11 @@ describe Member do
 
     it 'returns the price inclusive of vat for individuals' do
       m = Member.new(product_name: 'individual', address_country: 'GB')
+      expect(m.get_plan_price).to eq("£108.00 including £18.00 VAT")
+    end
+
+    it 'returns the price inclusive of vat for students' do
+      m = Member.new(product_name: 'student', address_country: 'GB')
       expect(m.get_plan_price).to eq("£108.00 including £18.00 VAT")
     end
 


### PR DESCRIPTION
This adds support for a [new student product](https://github.com/theodi/member-directory/issues/434)

The signup page URL for students is `/members/new?level=student`

## Deployment

* Chargify needs the student product setup (might already be there)  
I have it setup on the development system like this:  

![chargify-product-setup](https://cloud.githubusercontent.com/assets/6588/9327260/6cdb0d78-4597-11e5-8457-d52e47448f9e.png)

* Chargify needs the public signup page created  
This is a copy of the other signup pages with the correct student product selected

* Capsule CRM needs the new "student" level added to the membership tag  
  Settings -> Tags -> Membership -> Level
  
![2015-08-17 at 16 55](https://cloud.githubusercontent.com/assets/6588/9310881/a707238e-450a-11e5-821d-c2322bcd9308.png)