### PR TITLE
Fix problem where members are left in limbo

### DIFF
--- a/app/assets/stylesheets/members.css.scss
+++ b/app/assets/stylesheets/members.css.scss
@@ -20,3 +20,8 @@
   }
 }
 
+.pay-by-invoice {
+  font-size: 14px;
+  margin-top: 20px;
+}
+

--- a/app/views/members/payment.html.erb
+++ b/app/views/members/payment.html.erb
@@ -58,6 +58,12 @@
   <div class="control-group">
     <div class="controls">
       <input type="submit" class="btn btn-primary btn-large" value="<%= payment_button_label(@member, @discount_type) %>">
+
+      <% if @member.supporter? %>
+        <p class="pay-by-invoice">
+          <%= link_to("Or would you rather pay by invoice?", new_member_registration_path(:level => "supporter", :invoice => true)) %>
+        </p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/features/signup_as_individual.feature
+++ b/features/signup_as_individual.feature
@@ -47,17 +47,6 @@ Feature: Signup as an individual member
     And if I navigate away and then return
     Then the original origin value should be still be "odi-leeds"
 
-  Scenario: Member signs up and changes payment method half way through
-    When I enter my name and contact details
-    And I enter my address details
-    And I agree to the terms
-    When I click sign up
-    Then I am redirected to the payment page
-    And I should have a membership number generated
-    And I realise that I want to pay by invoice
-    Then I am returned to the thanks page
-    And a welcome email should be sent to me
-
   @javascript
   Scenario: Auto-update terms based on user input
     Given I want to sign up as an individual member

--- a/features/signup_as_individual.feature
+++ b/features/signup_as_individual.feature
@@ -47,6 +47,17 @@ Feature: Signup as an individual member
     And if I navigate away and then return
     Then the original origin value should be still be "odi-leeds"
 
+  Scenario: Member signs up and changes payment method half way through
+    When I enter my name and contact details
+    And I enter my address details
+    And I agree to the terms
+    When I click sign up
+    Then I am redirected to the payment page
+    And I should have a membership number generated
+    And I realise that I want to pay by invoice
+    Then I am returned to the thanks page
+    And a welcome email should be sent to me
+
   @javascript
   Scenario: Auto-update terms based on user input
     Given I want to sign up as an individual member

--- a/features/signup_as_supporter.feature
+++ b/features/signup_as_supporter.feature
@@ -137,6 +137,18 @@ Feature: Signup as a supporter member
     And my details should be queued for further processing
     When chargify verifies the payment
 
+  Scenario: Member signs up and changes payment method half way through
+    When I enter my name and contact details
+    And I enter my company details
+    And I enter my address details
+    And I agree to the terms
+    When I click sign up
+    Then I am redirected to the payment page
+    And I should have a membership number generated
+    And I realise that I want to pay by invoice
+    Then I am returned to the thanks page
+    And a welcome email should be sent to me
+
   @javascript
   Scenario: Auto-update terms based on user input
     When I enter my name and contact details

--- a/features/signup_as_supporter.feature
+++ b/features/signup_as_supporter.feature
@@ -146,6 +146,7 @@ Feature: Signup as a supporter member
     Then I am redirected to the payment page
     And I should have a membership number generated
     And I realise that I want to pay by invoice
+    And I follow the pay by invoice link
     Then I am returned to the thanks page
     And a welcome email should be sent to me
 

--- a/features/step_definitions/individual_signup_steps.rb
+++ b/features/step_definitions/individual_signup_steps.rb
@@ -24,3 +24,9 @@ end
 Then /^I should see a link to the right to cancel$/ do
   expect(find_link("right to cancel")).to be_visible
 end
+
+Then(/^I realise that I want to pay by invoice$/) do
+  # Member has been sent the invoice URL by us
+  visit("/members/new?level=#{@product_name}&invoice=true")
+end
+

--- a/features/step_definitions/individual_signup_steps.rb
+++ b/features/step_definitions/individual_signup_steps.rb
@@ -25,8 +25,3 @@ Then /^I should see a link to the right to cancel$/ do
   expect(find_link("right to cancel")).to be_visible
 end
 
-Then(/^I realise that I want to pay by invoice$/) do
-  # Member has been sent the invoice URL by us
-  visit("/members/new?level=#{@product_name}&invoice=true")
-end
-

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -397,3 +397,12 @@ Then(/^the original origin value should be still be "(.*?)"$/) do |origin|
   expect(field.value).to eq(origin)
 end
 
+Then(/^I realise that I want to pay by invoice$/) do
+  expect(page.find(".pay-by-invoice").text).to eq("Or would you rather pay by invoice?")
+end
+
+Then(/^I follow the pay by invoice link$/) do
+  # Member has been sent the invoice URL by us
+  visit("/members/new?level=#{@product_name}&invoice=true")
+end
+


### PR DESCRIPTION
This fixes #445 

The solution just forwards the member onto the thanks page so that the rest of the process can continue.

I'm not very happy with this solution, but it's probably the pragmatic one for now. What do you think @pezholio?