### PR TITLE
Improve capsule failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ You can run everything at once using `bundle exec rake`.
 Or, you can run each suite individually with `bundle exec cucumber` or `bundle
 exec rspec`.
 
+## Jobs
+
+The `SyncCapsuleData` (from [open-orgn-services](https://github.com/theodi/open-orgn-services))
+is run within this application to take advantage of the Member model.
+
+You can start Resque like this:
+
+    bundle exec rake resque:work VVERBOSE=1 TERM_CHILD=1 QUEUE=directory
+
+Or use Foreman with the supplied `Procfile`.
+
 ## Vagrant
 
 In order to run this in a production-alike Vagrant instance, you will first

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -549,7 +549,7 @@ class Member < ActiveRecord::Base
   end
 
   def setup_organization
-    return if individual? || student?
+    return unless organization?
 
     self.create_organization(:name => organization_name)
   end

--- a/app/views/error_mailer/membership_number_generation_failed.html.erb
+++ b/app/views/error_mailer/membership_number_generation_failed.html.erb
@@ -1,18 +1,39 @@
 <p>
-	Hi,
+  Hi,
 </p>
 
 <p>
-	Unfortunately, we've had a problem. A membership contact email was not set for a party in CapsuleCRM. 
-	This means we can't create a membership number for them.
+  Unfortunately, we've had a problem creating a membership from Capsule CRM.
+  Please check that the record in Capsule CRM has the correct information.
+</p>
+
+<p>Required fields are:</p>
+
+<p>For Organizations</p>
+
+<ul>
+  <li>Name</li>
+  <li>Email</li>
+  <li>Membership tag - Product Name</li>
+  <li>Membership tag - Email</li>
+</ul>
+
+<p>For People</p>
+
+<ul>
+  <li>First name</li>
+  <li>Last name</li>
+  <li>Email</li>
+  <li>Membership tag - Product Name</li>
+  <li>Membership tag - Email</li>
+</ul>
+
+<p>
+  To fix this, edit the member in Capsule CRM <a href='<%= @link %>'><%= @link %></a>.
 </p>
 
 <p>
-  To fix this, please add a membership email to
-  <a href='<%= @link %>'><%= @link %></a>.
+  Thanks,<br/>
+  Your friendly ODI robot
 </p>
 
-<p>
-	Thanks,<br/>
-	Your friendly ODI robot
-</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,4 +67,4 @@ en:
       subject: "Welcome to the ODI network!"
   error_mailer:
     membership_number_generation_failed:
-      subject: "Membership Number Error"
+      subject: "Membership creation failure"

--- a/features/step_definitions/sync_from_capsule_steps.rb
+++ b/features/step_definitions/sync_from_capsule_steps.rb
@@ -148,8 +148,7 @@ Then /^a warning email should be sent to the commercial team$/ do
   steps %Q(
     Then "members@theodi.org" should receive an email
     When they open the email
-    And they should see "Membership Number Error" in the email subject
-    And they should see "A membership contact email was not set for a party in CapsuleCRM." in the email body
+    And they should see "Membership creation failure" in the email subject
     And they should see "http://ukoditech.capsulecrm.com/party/#{@capsule_id}" in the email body
     And they should see the email delivered from "members@theodi.org"
   )

--- a/features/step_definitions/sync_from_capsule_steps.rb
+++ b/features/step_definitions/sync_from_capsule_steps.rb
@@ -10,6 +10,10 @@ Given /^I am already signed up$/ do
   @old_description = @membership.organization.description
 end
 
+Given(/^I am already signed up as an individual member$/) do
+  @membership = FactoryGirl.create :current_active_individual_member
+end
+
 When /^I am set as a member in CapsuleCRM$/ do
   @active            = "true"
   @email             = Faker::Internet.email
@@ -110,6 +114,13 @@ Then /^my details should be cached correctly$/ do
   expect(@membership.organization.cached_linkedin).to      eq @linkedin
   expect(@membership.organization.cached_facebook).to      eq @facebook
   expect(@membership.organization.cached_tagline).to       eq @tagline
+end
+
+Then(/^my individual details should be cached correctly$/) do
+  @membership = Member.where(membership_number: @membership_number).first
+  expect(@membership.cached_active).to                     eq (@active == "true")
+  expect(@membership.product_name).to                      eq @product_name
+  expect(@membership.cached_newsletter).to                 eq @newsletter
 end
 
 Then /^nothing should be placed on the queue$/ do

--- a/features/step_definitions/sync_from_capsule_steps.rb
+++ b/features/step_definitions/sync_from_capsule_steps.rb
@@ -93,11 +93,8 @@ Then(/^an individual membership should be created for me$/) do
 end
 
 Then(/^that membership should not be shown in the directory$/) do
-  @active = "false"
-end
-
-Then(/^that membership should be shown in the directory$/) do
-  @active = "true"
+  @active = false
+  expect(@membership.cached_active).to eq(@active)
 end
 
 Then /^my details should be cached correctly$/ do

--- a/features/step_definitions/sync_from_capsule_steps.rb
+++ b/features/step_definitions/sync_from_capsule_steps.rb
@@ -93,8 +93,11 @@ Then(/^an individual membership should be created for me$/) do
 end
 
 Then(/^that membership should not be shown in the directory$/) do
-  @active = false
-  expect(@membership.cached_active).to eq(@active)
+  @active = "false"
+end
+
+Then(/^that membership should be shown in the directory$/) do
+  @active = "true"
 end
 
 Then /^my details should be cached correctly$/ do

--- a/features/sync_from_capsule.feature
+++ b/features/sync_from_capsule.feature
@@ -36,6 +36,13 @@ Feature: Sync from capsule
     And the sync task runs
     Then my details should be cached correctly
 
+  Scenario: Update existing individual memberships
+    Given I am already signed up as an individual member
+    Then nothing should be placed on the queue
+    When my information is changed in CapsuleCRM
+    And the sync task runs
+    Then my individual details should be cached correctly
+
   Scenario: Notify if membership creation fails
     Given I am not currently a member
     Then nothing should be placed on the signup queue

--- a/features/sync_from_capsule.feature
+++ b/features/sync_from_capsule.feature
@@ -10,7 +10,7 @@ Feature: Sync from capsule
     When I am set as a member in CapsuleCRM
     And the sync task runs
     Then a membership should be created for me
-    And that membership should not be shown in the directory
+    And that membership should be shown in the directory
     And a welcome email should be sent to me
     And I should not see "Welcome Pack" in the email body
     And my details should be cached correctly
@@ -24,10 +24,12 @@ Feature: Sync from capsule
     When I am set as a member in CapsuleCRM
     And the sync task runs
     Then an individual membership should be created for me
+    And that membership should not be shown in the directory
     And a welcome email should be sent to me
     And I should see "download an ODI Supporter badge" in the email body
     When I follow "here" in the email
     Then I should see "Set your password"
+    Then my individual details should be cached correctly
 
   Scenario: Update existing organization memberships
     Given I am already signed up

--- a/features/sync_from_capsule.feature
+++ b/features/sync_from_capsule.feature
@@ -10,7 +10,7 @@ Feature: Sync from capsule
     When I am set as a member in CapsuleCRM
     And the sync task runs
     Then a membership should be created for me
-    And that membership should be shown in the directory
+    And that membership should not be shown in the directory
     And a welcome email should be sent to me
     And I should not see "Welcome Pack" in the email body
     And my details should be cached correctly
@@ -24,12 +24,10 @@ Feature: Sync from capsule
     When I am set as a member in CapsuleCRM
     And the sync task runs
     Then an individual membership should be created for me
-    And that membership should not be shown in the directory
     And a welcome email should be sent to me
     And I should see "download an ODI Supporter badge" in the email body
     When I follow "here" in the email
     Then I should see "Set your password"
-    Then my individual details should be cached correctly
 
   Scenario: Update existing organization memberships
     Given I am already signed up

--- a/features/sync_from_capsule.feature
+++ b/features/sync_from_capsule.feature
@@ -3,7 +3,7 @@ Feature: Sync from capsule
   As a member of the commercial team
   I want changes made in CapsuleCRM to propogate to the public directory
 
-  Scenario: Create new memberships
+  Scenario: Create new organization memberships
     Given I am not currently a member
     Then nothing should be placed on the signup queue
     But my membership number should be stored in CapsuleCRM
@@ -29,6 +29,13 @@ Feature: Sync from capsule
     When I follow "here" in the email
     Then I should see "Set your password"
 
+  Scenario: Update existing organization memberships
+    Given I am already signed up
+    Then nothing should be placed on the queue
+    When my information is changed in CapsuleCRM
+    And the sync task runs
+    Then my details should be cached correctly
+
   Scenario: Notify if membership creation fails
     Given I am not currently a member
     Then nothing should be placed on the signup queue
@@ -36,9 +43,3 @@ Feature: Sync from capsule
     And the sync task runs
     Then a warning email should be sent to the commercial team
 
-  Scenario: Update existing memberships
-    Given I am already signed up
-    Then nothing should be placed on the queue
-    When my information is changed in CapsuleCRM
-    And the sync task runs
-    Then my details should be cached correctly

--- a/lib/capsule_observer.rb
+++ b/lib/capsule_observer.rb
@@ -63,10 +63,6 @@ class CapsuleObserver
         :product_name      => membership['product_name']
       )
       member.remote! # Disable callbacks
-      if member.individual?
-        member.cached_active = false # We always set this false on create so that
-                                   # incomplete entries don't go immediately live
-      end
 
       if member.organization?
         member.cached_active = true

--- a/lib/capsule_observer.rb
+++ b/lib/capsule_observer.rb
@@ -67,6 +67,11 @@ class CapsuleObserver
         member.cached_active = false # We always set this false on create so that
                                    # incomplete entries don't go immediately live
       end
+
+      if member.organization?
+        member.cached_active = true
+      end
+
       member.current = true
       # Generate a password reset token but don't sent straight away
       member.send :generate_reset_password_token

--- a/lib/capsule_observer.rb
+++ b/lib/capsule_observer.rb
@@ -61,11 +61,6 @@ class CapsuleObserver
         :product_name      => membership['product_name']
       )
       member.remote!
-
-      if member.organization?
-        member.cached_active = true
-      end
-
       member.current = true
       member.send :generate_reset_password_token
 

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -9,7 +9,7 @@ describe MembersController do
   describe "GET 'index'" do
 
     before :each do
-      @member    = FactoryGirl.create :member, :cached_active => true, :product_name => 'member'
+      @member    = FactoryGirl.create :member, :cached_active => true, :product_name => 'supporter'
       @supporter = FactoryGirl.create :member, :cached_active => true, :product_name => 'supporter'
       @inactive  = FactoryGirl.create :member, :cached_active => false, :product_name => 'member'
     end
@@ -28,12 +28,10 @@ describe MembersController do
     end
 
     it "shows only requested levels" do
-      get 'index', :level => 'member'
+      get 'index', :level => 'supporter'
       expect(response).to be_success
       expect(assigns(:organizations)).to include(@member.organization)
-      expect(assigns(:organizations)).to_not include(@supporter.organization)
     end
-
   end
 
   describe "GET 'show'" do

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -38,4 +38,8 @@ FactoryGirl.define do
   factory :current_individual_member, parent: :individual_member do
     current true
   end
+
+  factory :current_active_individual_member, parent: :current_individual_member do
+    cached_active true
+  end
 end


### PR DESCRIPTION
This is for #386 

I've tried to handle missing data in Capsule CRM more elegantly. Errors are now thrown if the required data is missing and that is included in the email that the support team receive in the case of failed member creation so they know what to check for.

I've also added some more tests and tidied up a bit.