### PR TITLE
Change student greeting temporarily

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
   
   def greeting(resource)
     if @resource.try(:student?) && @resource.student?
-      "Dear #{@resource.first_name}"
+      "Dear Student"
     else
       if @resource.try(:contact_name)
         "Dear #{@resource.contact_name}"

--- a/features/signup_as_student.feature
+++ b/features/signup_as_student.feature
@@ -23,7 +23,7 @@ Feature: Signup as an student member
     And I should not have an organisation assigned to me
     And a welcome email should be sent to me
     And I should see "You’ve joined our network! Now what?" in the email subject
-    And I should see "Dear Ian" in the email body
+    And I should see "Dear Student" in the email body
     And I should see "Welcome to the Open Data Institute" in the email body
     And my details should be queued for further processing
     When chargify verifies the payment


### PR DESCRIPTION
The student first name is missing for some reason. Changing to "Student"
until we can first that issue.