### PR TITLE
Fix node coupons

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -106,7 +106,7 @@ class MembersController < ApplicationController
       redirect_to member_path(current_member)
     elsif request.post?
       current_member.update_attribute(:payment_frequency, params[:payment_frequency]) if params[:payment_frequency].present?
-      current_member.no_payment = true if params[:no_payment].present?
+      current_member.no_payment = true if @no_payment
       redirect_to ChargifyProductLink.for(current_member)
     else
       @member = current_member

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -100,6 +100,7 @@ class MembersController < ApplicationController
   def payment
     discount = Member::CHARGIFY_COUPON_DISCOUNTS[current_member.coupon]
     @discount_type = discount.nil? ? "" : discount[:type]
+    @no_payment = params[:no_payment] || (@discount_type == :free)
 
     if current_member.current?
       redirect_to member_path(current_member)

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -58,7 +58,7 @@ module MembersHelper
       "Complete"
     else
       if discount_type == :free
-        "Enter card details"
+        "Complete"
       else
         "Pay now"
       end

--- a/app/models/chargify_product_link.rb
+++ b/app/models/chargify_product_link.rb
@@ -40,10 +40,10 @@ class ChargifyProductLink
 
   def public_signup_page_key
     case
-    when member.individual?
-      :individual_pay_what_you_like
     when member.individual? && member.no_payment?
       :individual_pay_what_you_like_free
+    when member.individual?
+      :individual_pay_what_you_like
     when member.student? && member.no_payment?
       :individual_supporter_student_free
     when member.student?

--- a/app/views/members/payment.html.erb
+++ b/app/views/members/payment.html.erb
@@ -31,7 +31,7 @@
 <p>
 <%= form_tag payment_member_path(@member), method: 'post' do %>
   <%= hidden_field_tag(:coupon, params[:coupon]) if params[:coupon].present? %>
-  <%= hidden_field_tag(:no_payment, params[:no_payment]) if params[:no_payment].present? %>
+  <%= hidden_field_tag(:no_payment, @no_payment) if @no_payment %>
   <% if @member.monthly_payment_option? %>
     How would you like to pay?
     <div class="control-group">

--- a/app/views/members/payment.html.erb
+++ b/app/views/members/payment.html.erb
@@ -11,14 +11,12 @@
 <% case @discount_type %>
 <% when :free %>
 <p>
-    As part of this sign-up process we need to take your credit or debit card
-    details. Don’t worry, you’re still getting the first twelve months of
-    membership for free.
+    Congratulations! You’re receiving 12 months of free ODI membership. This 
+    will be set up on the next page.
 </p>
 <p>
-    After twelve months you’ll only be charged if you decide
-    to renew. We’ll give you plenty of notice before taking any payment from the
-    card and you are under absolutely no obligation to renew.
+    You’ll only have to enter your card details when you decide
+    to renew after twelve months.
 </p>
 <% when :discount %>
 <p>

--- a/features/signup_as_individual.feature
+++ b/features/signup_as_individual.feature
@@ -52,6 +52,7 @@ Feature: Signup as an individual member
 
   Scenario: Signup with coupon should not see amount dropdown
     Given that I want to sign up as an individual supporter
+    And the coupon code SUPERFREE is in Chargify
     When I visit the signup page with an coupon code of "SUPERFREE"
     Then I should not see the subscription amount
     When I enter my name and contact details

--- a/features/signup_as_individual.feature
+++ b/features/signup_as_individual.feature
@@ -53,4 +53,13 @@ Feature: Signup as an individual member
   Scenario: Signup with coupon should not see amount dropdown
     Given that I want to sign up as an individual supporter
     When I visit the signup page with an coupon code of "odi-leeds"
-    Then I should not see the subscription amount 
+    Then I should not see the subscription amount
+    When I enter my name and contact details
+    And I enter my address details
+    And I agree to the terms
+    When I click sign up
+    Then I am redirected to the payment page
+    And I should have a membership number generated
+    And I should have the product link "individual-pay-what-you-like-free"
+    And I am processed through chargify for the "individual-pay-what-you-like-free" option
+    When I click pay now

--- a/features/signup_as_individual.feature
+++ b/features/signup_as_individual.feature
@@ -61,6 +61,5 @@ Feature: Signup as an individual member
     When I click sign up
     Then I am redirected to the payment page
     And I should have a membership number generated
-    And I should have the product link "individual-pay-what-you-like-free"
     And I am processed through chargify for the "individual-pay-what-you-like-free" option
-    When I click pay now
+    When I click complete

--- a/features/signup_as_individual.feature
+++ b/features/signup_as_individual.feature
@@ -52,7 +52,7 @@ Feature: Signup as an individual member
 
   Scenario: Signup with coupon should not see amount dropdown
     Given that I want to sign up as an individual supporter
-    When I visit the signup page with an coupon code of "odi-leeds"
+    When I visit the signup page with an coupon code of "SUPERFREE"
     Then I should not see the subscription amount
     When I enter my name and contact details
     And I enter my address details

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -488,7 +488,7 @@ end
 
 When(/^I visit the signup page with an coupon code of "(.*?)"$/) do |coupon_code|
   @coupon_code = coupon_code
-  visit("/members/new?level=#{@product_name}&coupon=#{@coupon_code}&no_payment=true")
+  visit("/members/new?level=#{@product_name}&coupon=#{@coupon_code}")
 end
 
 Then(/^I should not see the subscription amount$/) do

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -222,6 +222,12 @@ Then /^I am processed through chargify for the "(.*?)" option$/ do |plan|
   allow(ChargifyProductLink).to receive(:for).and_return(chargify_return_members_path(params))
 end
 
+Then(/^I should have the product link "(.*?)"$/) do |plan|
+  member = Member.find_by_email(@email)
+
+  expect(ChargifyProductLink.new(member).public_signup_page_key).to eq(plan)
+end
+
 Then(/^the coupon code "(.*?)" is saved against my membership$/) do |coupon|
   @discount = 50
   member = Member.find_by_email(@email)
@@ -482,7 +488,7 @@ end
 
 When(/^I visit the signup page with an coupon code of "(.*?)"$/) do |coupon_code|
   @coupon_code = coupon_code
-  visit("/members/new?level=#{@product_name}&coupon=#{@coupon_code}")
+  visit("/members/new?level=#{@product_name}&coupon=#{@coupon_code}&no_payment=true")
 end
 
 Then(/^I should not see the subscription amount$/) do

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -230,12 +230,6 @@ Then /^I am processed through chargify for the "(.*?)" option$/ do |plan|
   allow(ChargifyProductLink).to receive(:for).and_return(chargify_return_members_path(params))
 end
 
-Then(/^I should have the product link "(.*?)"$/) do |plan|
-  member = Member.find_by_email(@email)
-
-  expect(ChargifyProductLink.new(member).public_signup_page_key).to eq(plan)
-end
-
 Then(/^the coupon code "(.*?)" is saved against my membership$/) do |coupon|
   @discount = 50
   member = Member.find_by_email(@email)

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -22,6 +22,14 @@ Given /^the student coupon code SUPERFREE is in Chargify$/ do
   Member.register_chargify_coupon_code(@coupon)
 end
 
+Given /^the coupon code SUPERFREE is in Chargify$/ do
+  @chargify_product_url = "http://test.host/product/individual-supporter"
+  @chargify_product_price = 800
+  @coupon = double(:code => "SUPERFREE", :percentage => 100)
+  Member.register_chargify_product_price("individual-supporter", @chargify_product_price*100)
+  Member.register_chargify_coupon_code(@coupon)
+end
+
 Given /^there is already an organization with the name I want to use$/ do
   FactoryGirl.create :member, :organization_name => 'FooBar Inc'
 end

--- a/spec/helpers/members_helper_spec.rb
+++ b/spec/helpers/members_helper_spec.rb
@@ -14,11 +14,11 @@ describe MembersHelper do
   describe "#payment_button_label" do
     let(:member) { double(student?: false) }
 
-    context "type if free" do
-      it "asks you to enter your card details" do
+    context "type is free" do
+      it "doesn't ask you to enter your card details" do
         discount_type = :free
 
-        expect(helper.payment_button_label(member, discount_type)).to eq("Enter card details")
+        expect(helper.payment_button_label(member, discount_type)).to eq("Complete")
       end
     end
 

--- a/spec/models/chargify_product_link_spec.rb
+++ b/spec/models/chargify_product_link_spec.rb
@@ -40,6 +40,7 @@ describe ChargifyProductLink do
      ENV["CHARGIFY_PAGE_IDS"] = "individual_supporter,1234"
 
      allow(member).to receive(:individual?).and_return(true)
+     allow(member).to receive(:no_payment?).and_return(false)
      allow(member).to receive(:plan).and_return("individual-supporter")
      allow(member).to receive(:subscription_amount).and_return(10)
      allow(member).to receive(:price_without_vat).and_return(8.33)
@@ -88,6 +89,15 @@ describe ChargifyProductLink do
         allow(member).to receive(:individual?).and_return(true)
 
         expect(subject.public_signup_page_key).to eq(:individual_pay_what_you_like)
+      end
+    end
+
+    context "free individual" do
+      it "should return 'individual_pay_what_you_like_free'" do
+        allow(member).to receive(:individual?).and_return(true)
+        allow(member).to receive(:no_payment?).and_return(true)
+
+        expect(subject.public_signup_page_key).to eq(:individual_pay_what_you_like_free)
       end
     end
 
@@ -156,6 +166,7 @@ describe ChargifyProductLink do
         :individual_supporter_student_free => "456",
         :supporter_monthly                 => "789",
         :individual_pay_what_you_like      => "111213",
+        :individual_pay_what_you_like_free => "1234",
         :supporter_annual                  => "345",
         :corporate_supporter_annual        => "678"
       )


### PR DESCRIPTION
There's a failing test here - it seems like the `no_payment` hidden field isn't showing