### PR TITLE
Revert "Bump mysql2 from 0.3.21 to 0.4.7"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'zeroclipboard-rails'
 
 # To use debugger
 # gem 'debugger'
-gem 'mysql2', '~> 0.4.7'
+gem 'mysql2', '~> 0.3.10'
 
 group :development, :test do
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
     multi_test (0.1.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.7)
+    mysql2 (0.3.21)
     nenv (0.3.0)
     nested_form (0.3.2)
     net-http-persistent (2.9.4)
@@ -588,7 +588,7 @@ DEPENDENCIES
   launchy
   mailcatcher
   mini_magick
-  mysql2 (~> 0.4.7)
+  mysql2 (~> 0.3.10)
   omniauth-google-oauth2
   poltergeist
   rabl


### PR DESCRIPTION
Reverts theodi/member-directory#702. MySQL doesnt activate after update. Needs properly looking at before updating.